### PR TITLE
Add dependency version constraints.

### DIFF
--- a/mediawiki.cabal
+++ b/mediawiki.cabal
@@ -113,22 +113,22 @@ library
                      MediaWiki.Util.Codec.Percent,
                      MediaWiki.Util.Codec.URLEncoder
    Ghc-Options:    -Wall -O2
-   Build-Depends:  base >= 3 && < 5, xml, HTTP >= 3001, network, mime, utf8-string
+   Build-Depends:  base >= 3 && < 5, xml, HTTP >= 3001, network >= 2.6, network-uri >= 2.6, mime < 4, utf8-string
 
 executable main {
-  Build-Depends:   mediawiki, base >= 3 && < 5, xml, HTTP >= 3001, network, mime, utf8-string
+  Build-Depends:   mediawiki, base >= 3 && < 5, xml, HTTP >= 3001, network >= 2.6, network-uri >= 2.6, mime < 4, utf8-string
   Main-is:         Main.hs
   Ghc-options:     -Wall
 }
 
 executable listCat {
-  Build-Depends:   mediawiki, base >= 3 && < 5, xml, HTTP >= 3001, network, mime, utf8-string, pretty
+  Build-Depends:   mediawiki, base >= 3 && < 5, xml, HTTP >= 3001, network >= 2.6, network-uri >= 2.6, mime < 4, utf8-string, pretty
   Main-is:         examples/ListCat.hs
   Ghc-options:     -Wall -iexamples
 }
 
 executable linksTo {
-  Build-Depends:   mediawiki, base >= 4, xml, HTTP >= 3001, network, mime, utf8-string, pretty
+  Build-Depends:   mediawiki, base >= 4, xml, HTTP >= 3001, network >= 2.6, network-uri >= 2.6, mime < 4, utf8-string, pretty
   Main-is:         examples/LinksTo.hs
   Ghc-options:     -Wall -iexamples
 }

--- a/mediawiki.cabal
+++ b/mediawiki.cabal
@@ -113,22 +113,22 @@ library
                      MediaWiki.Util.Codec.Percent,
                      MediaWiki.Util.Codec.URLEncoder
    Ghc-Options:    -Wall -O2
-   Build-Depends:  base >= 3 && < 5, xml, HTTP >= 3001, network >= 2.6, network-uri >= 2.6, mime < 4, utf8-string
+   Build-Depends:  base >= 3 && < 5, xml, HTTP >= 3001, network >= 2.6, network-uri >= 2.6, mime < 0.4, utf8-string
 
 executable main {
-  Build-Depends:   mediawiki, base >= 3 && < 5, xml, HTTP >= 3001, network >= 2.6, network-uri >= 2.6, mime < 4, utf8-string
+  Build-Depends:   mediawiki, base >= 3 && < 5, xml, HTTP >= 3001, network >= 2.6, network-uri >= 2.6, mime < 0.4, utf8-string
   Main-is:         Main.hs
   Ghc-options:     -Wall
 }
 
 executable listCat {
-  Build-Depends:   mediawiki, base >= 3 && < 5, xml, HTTP >= 3001, network >= 2.6, network-uri >= 2.6, mime < 4, utf8-string, pretty
+  Build-Depends:   mediawiki, base >= 3 && < 5, xml, HTTP >= 3001, network >= 2.6, network-uri >= 2.6, mime < 0.4, utf8-string, pretty
   Main-is:         examples/ListCat.hs
   Ghc-options:     -Wall -iexamples
 }
 
 executable linksTo {
-  Build-Depends:   mediawiki, base >= 4, xml, HTTP >= 3001, network >= 2.6, network-uri >= 2.6, mime < 4, utf8-string, pretty
+  Build-Depends:   mediawiki, base >= 4, xml, HTTP >= 3001, network >= 2.6, network-uri >= 2.6, mime < 0.4, utf8-string, pretty
   Main-is:         examples/LinksTo.hs
   Ghc-options:     -Wall -iexamples
 }


### PR DESCRIPTION
This fixes compilation issues caused by changes in the network and mime packages. I added version constraints on dependencies due to changes that have broken the library.
